### PR TITLE
feat: GoogleBooksApi 로 바코드 연동 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,4 +220,7 @@ gradle-app.setting
 # Java heap dump
 *.hprof
 
+### API KEYS ###
+application-API-KEY.properties
+
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,windows,visualstudiocode,macos

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.7'
 //	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
-
+	implementation 'com.google.code.gson:gson:2.10.1'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.h2database:h2'

--- a/src/main/java/kernel/hackerthon/library/controller/BookApiController.java
+++ b/src/main/java/kernel/hackerthon/library/controller/BookApiController.java
@@ -1,0 +1,48 @@
+package kernel.hackerthon.library.controller;
+
+import com.google.gson.Gson;
+import kernel.hackerthon.library.dto.GoogleBooksResponse;
+import kernel.hackerthon.library.service.BookService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@RestController
+public class BookApiController {
+
+    private final BookService bookService;
+
+    @Value("${google-books-api-key}")
+    private String apiKey;
+
+    @PostMapping("/search")
+    public String searchBookWithIsbn(@RequestBody String isbnData) {
+        String json = null;
+        try {
+            Gson gsonRequest = new Gson();
+            Map<Object, Object> requestMap = new HashMap<>();
+            requestMap = (Map<Object, Object>)gsonRequest.fromJson(isbnData, requestMap.getClass());
+            requestMap.put("apiKey", apiKey);
+
+            GoogleBooksResponse response = bookService.searchBookWithIsbn(requestMap);
+
+            Gson gsonResponse = new Gson();
+            Map<Object, Object> responseMap = new HashMap<>();
+            responseMap.put("bookname", response.getItems().get(0).getVolumeInfo().getTitle());
+
+            json = gsonResponse.toJson(responseMap);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return json;
+    }
+
+}

--- a/src/main/java/kernel/hackerthon/library/controller/BookController.java
+++ b/src/main/java/kernel/hackerthon/library/controller/BookController.java
@@ -6,6 +6,7 @@ import kernel.hackerthon.library.repository.BookRepository;
 
 import kernel.hackerthon.library.service.BookService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,9 @@ import java.util.Optional;
 @Controller
 public class BookController {
     private final BookService bookService;
+
+
+    private String apiKey;
 
     //@PostMapping("api/v1/books")
     //private ResponseEntity<Book> addBook(@RequestBody AddBookRequest addBookRequest){
@@ -68,7 +72,10 @@ public class BookController {
     }
 
     @GetMapping("/add")
-    public String showAddBookForm(AddBookRequest addBookRequest) { return "addingBooksForm"; }
+    public String showAddBookForm(AddBookRequest addBookRequest) {
+        System.out.println(apiKey);
+        return "addingBooksForm";
+    }
 
     @PostMapping("/add")
     public String addBook(AddBookRequest addBookRequest) {

--- a/src/main/java/kernel/hackerthon/library/dto/GoogleBooksResponse.java
+++ b/src/main/java/kernel/hackerthon/library/dto/GoogleBooksResponse.java
@@ -1,0 +1,62 @@
+package kernel.hackerthon.library.dto;
+
+import java.util.List;
+
+public class GoogleBooksResponse {
+    private String kind;
+    private int totalItems;
+    private List<BookInfo> items;
+
+    public static class BookInfo {
+        private VolumeInfo volumeInfo;
+
+        public VolumeInfo getVolumeInfo() {
+            return volumeInfo;
+        }
+
+        public void setVolumeInfo(VolumeInfo volumeInfo) {
+            this.volumeInfo = volumeInfo;
+        }
+    }
+
+    public static class VolumeInfo {
+        private String title;
+        private List<String> authors;
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public List<String> getAuthors() {
+            return authors;
+        }
+
+        public void setAuthors(List<String> authors) {
+            this.authors = authors;
+        }
+    }
+
+    public String getKind() {
+        return kind;
+    }
+
+    public int getTotalItems() {
+        return totalItems;
+    }
+
+    public void setTotalItems(int totalItems) {
+        this.totalItems = totalItems;
+    }
+
+    public List<BookInfo> getItems() {
+        return items;
+    }
+
+    public void setItems(List<BookInfo> items) {
+        this.items =items;
+    }
+}

--- a/src/main/java/kernel/hackerthon/library/service/BookService.java
+++ b/src/main/java/kernel/hackerthon/library/service/BookService.java
@@ -4,6 +4,7 @@ import kernel.hackerthon.library.domain.Book;
 import kernel.hackerthon.library.domain.Rental;
 import kernel.hackerthon.library.domain.User;
 import kernel.hackerthon.library.dto.AddBookRequest;
+import kernel.hackerthon.library.dto.GoogleBooksResponse;
 import kernel.hackerthon.library.repository.BookRepository;
 import kernel.hackerthon.library.repository.RentalRepository;
 import kernel.hackerthon.library.repository.UserRepository;
@@ -11,12 +12,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDateTime;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -38,6 +37,21 @@ public class BookService {
 
     public Optional<Book> getBook(Long bookId){
         return bookRepository.findById(bookId);
+    }
+
+    public GoogleBooksResponse searchBookWithIsbn(Map<Object, Object> map) {
+        String isbn = (String) map.get("isbn");
+        String apiKey = (String) map.get("apiKey");
+
+        String apiUrl = "https://www.googleapis.com/books/v1/volumes?q=isbn:" + isbn + "&key=" + apiKey;
+
+        System.out.println(apiUrl);
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        GoogleBooksResponse response = restTemplate.getForObject(apiUrl, GoogleBooksResponse.class);
+
+        return response;
     }
 
 //    public void borrowBook(Long bookId, Long userId){

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,9 @@ spring:
       enabled: true
       path: /h2-console
 
+  profiles:
+    include: API-KEY
+
   datasource:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:~/kernelLibrary

--- a/src/main/resources/templates/addingBooksForm.html
+++ b/src/main/resources/templates/addingBooksForm.html
@@ -6,6 +6,7 @@
     <title>책 등록</title>
     <link rel="stylesheet" href="https://unpkg.com/mvp.css">
     <script src="https://cdn.jsdelivr.net/npm/quagga"></script>
+    <script src="https://cdn.bootcss.com/jquery/1.11.3/jquery.min.js"></script>
 </head>
 <body>
     <div>
@@ -59,8 +60,20 @@
 
 
         Quagga.onDetected(data => {
-            const code = data.codeResult.code;
-            alert("스캔된 데이터: " + code);
+            alert(data.codeResult.code);
+            const inputData = { "isbn" : data.codeResult.code };
+
+            $.ajax({
+                url: "/api/search",
+                type: "post",
+                data: JSON.stringify(inputData),
+                dataType: "json",
+                contentType: "application/json;charset=UTF-8",
+                async: false,
+                success: function(data) {
+                    document.getElementById("bookname").value = data.bookname;
+                }
+            })
         });
 
     </script>


### PR DESCRIPTION
바코드를 QuaggaJS 라이브러리를 사용하여 정보를 읽어내고 해당 정보로 Google API 단에 비동기 요청을 보내 데이터를 가져옵니다.
관련 GoogleBooksResponse Dto는 구조를 그대로 해야해서 우선은 Map을 파싱해서 필요한 데이터만 담아오는 식인데 response 객체 그 자체로 담아오는게 나을지 의견도 함께 부탁드립니다.

API key 관련해서는 슬랙 메세지 확인해주세요 

related issue: #24